### PR TITLE
1.0.1 - Bug fixes, adding issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,96 @@
+name: Bug Report
+description: Create a report to help improve the product
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: "## Report issues with Kandji's AutoPkg processor, KAPPA"
+  - type: checkboxes
+    id: nodupes
+    attributes:
+      label: New Bug Check
+      description: Search for [similar bug reports](../issues) before submitting
+      options:
+        - label: _I have searched the repo and confirm this is a new bug report_
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please provide a clear and concise description of the issue
+      placeholder: |
+        When I run...
+        The result is...
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduce
+      description: Steps to reproduce the issue
+      placeholder: |
+        autopkg run -vvv RECIPE.pkg --post io.kandji.kappa/KAPPA ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What is the expected behavior?
+      placeholder: |
+        I would expect...
+    validations:
+      required: true
+  - type: textarea
+    id: response
+    attributes:
+      label: AutoPkg response
+      description: Output of the `autopkg run -vvv` command containing the error/exception (redacting sensitive information)
+      render: python
+      placeholder: |
+        Traceback (most recent call last):
+          File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
+            self.env = processor.process()
+          File "/Library/AutoPkg/autopkglib/__init__.py", line 626, in process
+            self.main()
+          File "~/Library/AutoPkg/RecipeRepos/com.github.kandji-inc.KAPPA/KAPPA.py", line 227, in main
+            self.populate_from_config()
+          File "~/Library/AutoPkg/RecipeRepos/com.github.kandji-inc.KAPPA/helpers/configs.py", line 330, in populate_from_config
+            raise ProcessorError("ERROR: Kandji API URL is invalid! Run 'setup.command' and try again")
+        autopkglib.ProcessorError: ERROR: Kandji API URL is invalid! Run 'setup.command' and try again
+          File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
+            self.env = processor.process()
+        ERROR: Kandji API URL is invalid! Run 'setup.command' and try again
+    validations:
+      required: true
+  - type: input
+    id: autopkgvers
+    attributes:
+      label: AutoPkg version
+      description: Output of `autopkg version`
+      placeholder: |
+        2.7.2
+    validations:
+      required: true
+  - type: textarea
+    id: macOSvers
+    attributes:
+      label: macOS version
+      description: Output of `/usr/bin/sw_vers`
+      render: bash
+      placeholder: |
+        ProductName:        macOS
+        ProductVersion:     14.4.1
+        BuildVersion:       23E224
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Info
+      description: Additional info you want to provide such as logs, system info, screenshots, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature Request
+description: Create a request for a new feature or functionality
+title: "[Feature Request] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: "## Request new functionality for Kandji's AutoPkg processor, KAPPA"
+  - type: checkboxes
+    id: nodupes
+    attributes:
+      label: New Request Check
+      description: Search for [similar feature requests](../issues) before submitting
+      options:
+        - label: _I have searched the repo and confirm this is a new feature request_
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please describe your feature request below
+      placeholder: |
+        I would like KAPPA to be able to...
+        So that I can...
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context or screenshots about the feature request here
+    validations:
+      required: false

--- a/helpers/configs.py
+++ b/helpers/configs.py
@@ -219,12 +219,17 @@ class Configurator(Processor):
                     category.get("id") for category in self.self_service if category.get("name") == ss_name
                 )
             except StopIteration:
-                # Set category id to default (None check performed later)
-                ss_assignment = (
-                    next(category.get("id") for category in self.self_service if category.get("name") == ss_default)
-                    if ss_default
-                    else None
-                )
+                self.output(f"WARNING: Provided category '{ss_name}' not found in Self Service!") if ss_name is not None else None
+                try:
+                    # Set category id to default (None check performed later)
+                    ss_assignment = (
+                        next(category.get("id") for category in self.self_service if category.get("name") == ss_default)
+                        if ss_default
+                        else None
+                    )
+                except StopIteration:
+                    self.output(f"WARNING: Default category '{ss_default}' not found in Self Service!")
+                    ss_assignment = None
             # Only reassign/override if not already set
             if ss_type == "prod":
                 if ss_name is not None:


### PR DESCRIPTION
## ❓ _Why This Change_
- Bug fixes
- Adding new issue templates for feature requests and bug reports

## 🆕 _What Changed_
#### **Bug fixes**:
- Resolved an issue where a config-defined Self Service category missing in Kandji caused an error
#### **Miscellaneous**:
- Added new GH templates for feature requests and bug reports

## 🧪 _Test Results_
- [x] Validated these changes resolve identified bugs present in `1.0.0`

## :shipit: _Ready Checks_
- [x] These changes have been carefully tested across multiple macOS versions
- [x] Where logical, code updates include inline comments/docstrings