### PR TITLE
1.0.2 - Bug fixes, bypass loading user zsh dotfiles

### DIFF
--- a/audit_app_and_version.zsh
+++ b/audit_app_and_version.zsh
@@ -1,10 +1,10 @@
-#!/bin/zsh
+#!/bin/zsh -f
 #
 # Audit script used to enforce Kandji custom app; programmatically populated during KAPPA runtime
-# Searches for install via populated bundle identifier/app name or from receipt DB given package ID 
+# Searches for install via populated bundle identifier/app name or from receipt DB given package ID
 # If not found, immediately triggers custom app installation (regardless of any configured delays)
 # If found, determines if version enforcement due; if so, triggers install if installed < required
-# If app is open in foreground, prompts user to close app with one-time option to defer one hour 
+# If app is open in foreground, prompts user to close app with one-time option to defer one hour
 
 ##############################
 ########## VARIABLES #########
@@ -202,7 +202,7 @@ function check_blocking_proc() {
         fi
         return 0
     fi
-    
+
     # If open, assign values from lsappinfo
     ls_bundle_name=$(grep "CFBundleName" <<< "${app_open_check}" | cut -d '"' -f4)
     ls_display_name=$(grep "LSDisplayName" <<< "${app_open_check}" | cut -d '"' -f4)
@@ -278,7 +278,7 @@ function prompt_close_app() {
         giving up after 300
     end tell
 EOF
-)
+    )
     exitc=$?
 
     if grep -q "got an error: Application" <<< ${applescript_out}; then
@@ -445,8 +445,9 @@ function validate_version() {
 function main() {
 
     # Set ID for logging to APP_NAME, PKG_ID, or BUNDLE_ID
+    # shellcheck disable=SC2299
     IDENTIFIER="${${APP_NAME:-$PKG_ID}:-$BUNDLE_ID}"
-    
+
     if [[ -z ${BUNDLE_ID} && -z ${APP_NAME} ]]; then
         echo "Neither BUNDLE_ID nor APP_NAME defined"
         if [[ -n ${PKG_ID} ]]; then

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -100,7 +100,6 @@ class Utilities(Processor):
             else curl_shell_exec
         )
         # Shell out to cURL and validate success
-        print(f"Running cURL command: {curl_shell_exec}")
         raw_out = run(curl_shell_exec, stdout=PIPE, stderr=STDOUT, shell=True, check=False)
         exit_code = raw_out.returncode
         decoded_out = raw_out.stdout.decode().strip()
@@ -147,6 +146,8 @@ class Utilities(Processor):
                     self.s3_generated_req = response
                 case "upload":
                     self.output(f"Successfully uploaded {self.pkg_name}!")
+                    # Initial sleep allowing S3 to process upload
+                    time.sleep(5)
                 case "create" | "update":
                     custom_app_id = response.get("id")
                     custom_name = response.get("name")
@@ -516,9 +517,8 @@ class Utilities(Processor):
                 f"Found Duplicates of Custom App {self.custom_app_name}",
                 f"{slack_body}",
             )
-            raise ProcessorError(
-                f"More than one match ({len(app_picker)}) returned for provided LI name! Cannot upload...\n{slack_body}"
-            )
+            # Return None to bypass remaining steps
+            return None
         try:
             return next(iter(app_picker))
         except StopIteration:


### PR DESCRIPTION
## ❓ _Why This Change_
- Bug/security fixes

## 🆕 _What Changed_
#### **Bug fixes**:
- Resolved an issue where certain non-fatal errors could return exceptions
#### **Miscellaneous**:
- Added `-f` flag (equivalent to `--no-rcs`) to `#!/bin/zsh` in `audit_app_and_version.zsh`
  - This suppresses the evaluation/execution of user `zsh` dotfiles during runtime
- Various formatting changes

## 🧪 _Test Results_
- [x] Validated these changes resolve identified issues present in `1.0.1`

## :shipit: _Ready Checks_
- [x] These changes have been carefully tested across multiple macOS versions
- [x] Where logical, code updates include inline comments/docstrings
