### PR TITLE
Pinned AutoPkg Version Update

### DIFF
--- a/setup.command
+++ b/setup.command
@@ -31,6 +31,7 @@
 # Provide arg support to only set config file
 zparseopts -D -E -a opts h -help c -config m -map r -reset
 # Set args for help and show message
+# shellcheck disable=SC2154
 if (( ${opts[(I)(-h|--help)]} )); then
     /bin/cat <<EOF
 Usage: ./setup.command [-h/--help|-c/--config|-m/--map|-r/--reset]

--- a/setup.command
+++ b/setup.command
@@ -537,7 +537,7 @@ function check_store_keychain() {
                     exit 1
                 fi
                 security add-generic-password -U -a "KAPPA" -s "${token_name}" -w "${BEARER_TOKEN}" \
-                -T "/usr/bin/security" -T "${ZSH_ARGZERO}" ${user_keychain_path}
+                    -T "/usr/bin/security" -T "${ZSH_ARGZERO}" ${user_keychain_path}
                 check_store_keychain
             fi
         else

--- a/setup.command
+++ b/setup.command
@@ -369,8 +369,10 @@ function prompt_for_value() {
     key_name=${1}
     example_val=${2}
     echo
+    # @formatter:off
     read "CONFIG_VALUE?Enter value for ${key_name} (e.g. ${example_val}):
 "
+    # @formatter:on
     if [[ -n ${CONFIG_VALUE} ]]; then
         if grep -q -w -E "${value_regex_pattern}" <<< "${CONFIG_VALUE}"; then
             return 0

--- a/setup.command
+++ b/setup.command
@@ -74,8 +74,8 @@ user_keychain_path=$(security login-keychain | xargs)
 
 # AutoPkg download/shasum variables
 autopkg_latest_url="https://api.github.com/repos/autopkg/autopkg/releases/latest"
-autopkg_pinned_pkg="https://github.com/autopkg/autopkg/releases/download/v2.7.2/autopkg-2.7.2.pkg"
-autopkg_pinned_shasum="2ff34daf02256ad81e2c74c83a9f4c312fa2f9dd212aba59e0cef0e6ba1be5c9" # pragma: allowlist secret
+autopkg_pinned_pkg="https://github.com/autopkg/autopkg/releases/download/v2.7.3/autopkg-2.7.3.pkg"
+autopkg_pinned_shasum="1944a69aad18b0b9618b48292d115412a98ca165b626f48b11bbc59b504af082" # pragma: allowlist secret
 autopkg_temp_dl="/tmp/autopkg.pkg"
 
 ##############################


### PR DESCRIPTION
## ❓ _Why This Change_
- `setup.command` was installing an outdated AutoPkg verison

## 🆕 _What Changed_
- Updated the pinned AutoPkg version to 2.7.3 
- Updated the pinned version hash to match the expected download
- Added linter/formatter directives for `shellcheck` and `beautysh`
- Formatted security command for readability

## 🧪 _Test Results_

### AutoPkg install

```
anka@arm-15_0_0 KAPPA % ./setup.command


########################################################
####### Kandji AutoPkg Processor Actions (KAPPA) #######
########################################################



###################################
####### KAPPA Initial Setup #######
###################################

... skipped for brevity ...

No AutoPkg found! Download and install now? (recommended) (Y/N):Y
07:23:26 AM : AutoPkg download complete — beginning install...
07:23:26 AM : INFO: You may be sudo prompted to complete AutoPkg installation
installer: Package name is autopkg
installer: Installing at base path /
installer: The install was successful.
07:23:30 AM : Successfully installed AutoPkg


####################################
####### KAPPA Setup Complete #######
####################################

anka@arm-15_0_0 KAPPA % autopkg version
WARNING: Did not load any default preferences.
2.7.3
```

### Package Upload

```
anka@arm-15_1_1 KAPPA % autopkg run -v com.github.autopkg.pkg.googlechromepkg --post=io.kandji.kappa/KAPPA
Processing com.github.autopkg.pkg.googlechromepkg...
WARNING: com.github.autopkg.pkg.googlechromepkg is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 19 Nov 2024 09:22:28 GMT
URLDownloader: Storing new ETag header: "387afe0"
URLDownloader: Downloaded /Users/anka/Library/AutoPkg/Cache/com.github.autopkg.pkg.googlechromepkg/downloads/GoogleChrome.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "GoogleChrome.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-11-19 07:53:25 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Google LLC (EQHXZ8M8AV)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            40 02 6A 12 12 38 F4 E0 3F 7B CE 86 FA 5A 22 2B DA 7A 3A 20 70 FF
CodeSignatureVerifier:            28 0D 86 AA 4E 02 56 C5 B2 B4
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Unpacked /Users/anka/Library/AutoPkg/Cache/com.github.autopkg.pkg.googlechromepkg/downloads/GoogleChrome.pkg to /Users/anka/Library/AutoPkg/Cache/com.github.autopkg.pkg.googlechromepkg/unpack
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/anka/Library/AutoPkg/Cache/com.github.autopkg.pkg.googlechromepkg/unpack/GoogleChrome.pkg/Payload to /Users/anka/Library/AutoPkg/Cache/com.github.autopkg.pkg.googlechromepkg/unpack
PlistReader
PlistReader: Reading: /Users/anka/Library/AutoPkg/Cache/com.github.autopkg.pkg.googlechromepkg/unpack/Google Chrome.app/Contents/Info.plist
PlistReader: Assigning value of '131.0.6778.86' to output variable 'version'
PkgCopier
PkgCopier: Copied /Users/anka/Library/AutoPkg/Cache/com.github.autopkg.pkg.googlechromepkg/downloads/GoogleChrome.pkg to /Users/anka/Library/AutoPkg/Cache/com.github.autopkg.pkg.googlechromepkg/GoogleChrome-131.0.6778.86.pkg
PathDeleter
PathDeleter: Deleted /Users/anka/Library/AutoPkg/Cache/com.github.autopkg.pkg.googlechromepkg/unpack
io.kandji.kappa/KAPPA
KAPPA: INFO:
Application Name: 'Google Chrome.app'
Bundle Identifier: 'com.google.Chrome'
Application Version: '131.0.6778.86'
KAPPA: Beginning file upload of GoogleChrome-131.0.6778.86.pkg...
KAPPA: Successfully uploaded GoogleChrome-131.0.6778.86.pkg!
KAPPA: Searching for GoogleChrome (AutoPkg) from list of custom apps
KAPPA: WARNING: No existing LI found for provided name 'GoogleChrome (AutoPkg)'!
KAPPA: Creating as new custom app...
KAPPA: WARNING: Could not find existing custom app to update — creating as new
KAPPA: SUCCESS: Custom App Create
KAPPA: Custom App 'GoogleChrome (AutoPkg)' available at 'tester.kandji.io/library/custom-apps/b2f7ddc2-53db-4082-a8e0-3a87d7644c64'
Receipt written to /Users/anka/Library/AutoPkg/Cache/com.github.autopkg.pkg.googlechromepkg/receipts/com.github.autopkg.pkg-receipt-20241122-085828.plist

The following new items were downloaded:
    Download Path
    -------------
    /Users/anka/Library/AutoPkg/Cache/com.github.autopkg.pkg.googlechromepkg/downloads/GoogleChrome.pkg

The following packages were copied:
    Pkg Path
    --------
    /Users/anka/Library/AutoPkg/Cache/com.github.autopkg.pkg.googlechromepkg/GoogleChrome-131.0.6778.86.pkg
anka@arm-15_1_1 KAPPA %
```

## :shipit: _Ready Checks_
- [x] These changes have been carefully tested across multiple macOS versions
- [x] Where logical, code updates include inline comments/docstrings
