### PR TITLE
Feature: Per Recipe enforcement delays

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ KAPPA supports both in-recipe and centralized options for customizing your AutoP
   - Custom app name (test)
   - Self Service category
   - Self Service category (test)
+  - Enforcement delay overrides (prod and/or test)
   - [See below](#autopkg-recipe-config) for an overview of available options and a sample config
 
 > [!NOTE]
@@ -307,6 +308,9 @@ Instructions for creating a Kandji API token [can be found here](https://support
 | `custom_app.test_name`   | `str` | Name of test custom app to be created/updated                       |
 | `custom_app.ss_category` | `str` | Toggles on Self Service enforcement for `prod_name` and sets category       |
 | `custom_app.test_category`| `str`| Toggles on Self Service enforcement for `test_name` and sets category  |
+| `enforcement_delays`| `dict`| Dictionary overriding global enforcement delay values per-recipe |
+| `enforcement_delays.prod`| `int`| Days before enforcement for production (overrides `config.json`) |
+| `enforcement_delays.test`| `int`| Days before enforcement for testing (overrides `config.json`) |
 
 
 #### Example Recipe/Override XML
@@ -330,6 +334,13 @@ Instructions for creating a Kandji API token [can be found here](https://support
                         <string>Productivity</string>
                         <key>test_category</key>
                         <string>Utilities</string>
+                    </dict>
+                    <key>enforcement_delays</key>
+                    <dict>
+                        <key>prod</key>
+                        <integer>7</integer>
+                        <key>test</key>
+                        <integer>0</integer>
                     </dict>
                 </dict>
             </dict>

--- a/helpers/configs.py
+++ b/helpers/configs.py
@@ -98,6 +98,8 @@ class Configurator(Processor):
         self.recipe_dry_run = self.env.get("dry_run", None)
         # Assign dict with custom app info
         self.recipe_custom_app = self.env.get("custom_app", None)
+        # Check if recipe has enforcement delay overrides
+        self.recipe_enforcement_delays = self.env.get("enforcement_delays", None)
         if self.recipe_custom_app:
             self.recipe_custom_name = self.recipe_custom_app.get("prod_name", None)
             self.recipe_test_name = self.recipe_custom_app.get("test_name", None)
@@ -172,8 +174,13 @@ class Configurator(Processor):
         )
         # Assign enforcement delays for audits
         if config_enforcement.get("delays"):
-            self.test_delay = config_enforcement.get("delays").get("test")
-            self.prod_delay = config_enforcement.get("delays").get("prod")
+            global_delays = config_enforcement.get("delays")
+            self.test_delay = global_delays.get("test")
+            self.prod_delay = global_delays.get("prod")
+            # Override with recipe values if provided
+            if self.recipe_enforcement_delays:
+                self.test_delay = self.recipe_enforcement_delays.get("test", self.test_delay)
+                self.prod_delay = self.recipe_enforcement_delays.get("prod", self.prod_delay)
 
         self.dry_run = False
         if (self.recipe_dry_run or self.default_dry_run) is True:

--- a/helpers/configs.py
+++ b/helpers/configs.py
@@ -173,14 +173,22 @@ class Configurator(Processor):
             else "install_once"
         )
         # Assign enforcement delays for audits
+        self.test_delay = None
+        self.prod_delay = None
         if config_enforcement.get("delays"):
             global_delays = config_enforcement.get("delays")
             self.test_delay = global_delays.get("test")
             self.prod_delay = global_delays.get("prod")
-            # Override with recipe values if provided
-            if self.recipe_enforcement_delays:
-                self.test_delay = self.recipe_enforcement_delays.get("test", self.test_delay)
-                self.prod_delay = self.recipe_enforcement_delays.get("prod", self.prod_delay)
+        # Override with recipe values if provided (independent of global delays)
+        if self.recipe_enforcement_delays:
+            self.output(
+                f"Recipe override: enforcement delays "
+                f"prod={self.recipe_enforcement_delays.get('prod', self.prod_delay)}, "
+                f"test={self.recipe_enforcement_delays.get('test', self.test_delay)} "
+                f"(global: prod={self.prod_delay}, test={self.test_delay})"
+            )
+            self.test_delay = self.recipe_enforcement_delays.get("test", self.test_delay)
+            self.prod_delay = self.recipe_enforcement_delays.get("prod", self.prod_delay)
 
         self.dry_run = False
         if (self.recipe_dry_run or self.default_dry_run) is True:

--- a/helpers/configs.py
+++ b/helpers/configs.py
@@ -173,8 +173,7 @@ class Configurator(Processor):
             else "install_once"
         )
         # Assign enforcement delays for audits
-        self.test_delay = None
-        self.prod_delay = None
+        self.test_delay = self.prod_delay = None
         if config_enforcement.get("delays"):
             global_delays = config_enforcement.get("delays")
             self.test_delay = global_delays.get("test")


### PR DESCRIPTION
## ❓ _Why This Change_
- Global enforcement delays in `config.json` apply uniformly to all recipes, but some apps (e.g. browsers, security tools) need faster enforcement while others benefit from a longer grace period. There's currently no way to set per-recipe delay values without changing the global config.

## 🆕 _What Changed_
- Added `enforcement_delays` as an optional recipe/override Input key (`dict` with `prod` and/or `test` integer values) that overrides the global `li_enforcement.delays` from `config.json`
- Initialized `self.test_delay` and `self.prod_delay` to `None` before the global delays conditional to prevent `AttributeError` if `delays` is missing from `config.json`
- Recipe override logic runs independently of global delays being configured — recipes can define `enforcement_delays` even if no global delays exist
- Added diagnostic logging when recipe overrides are applied, showing both recipe and global values
- Updated README with documentation table, feature bullet, and example XML

## 🧪 _Test Results_
```
KAPPA: Recipe override: enforcement delays prod=7, test=0 (global: prod=5, test=0)
KAPPA: DRY RUN: GoogleChromePkg.pkg.recipe will not make any Custom App modifications!
KAPPA: INFO:
Application Name: 'Google Chrome.app'
Bundle Identifier: 'com.google.Chrome'
Application Version: '145.0.7632.46'
KAPPA: DRY RUN: Would upload PKG '...GoogleChrome-145.0.7632.46.pkg cURL POST to 'https://kandji-prd.s3.amazonaws.com/'
KAPPA: DRY RUN: Would create Custom App 'GoogleChrome (AutoPkg)' with cURL POST to '...api/v1/library/custom-apps'

Verified enforcement_delays dict present in AutoPkg receipt plist:
enforcement_delays = Dict {
prod = 7
test = 0
}

```


## :shipit: _Ready Checks_
- [x] These changes have been carefully tested across multiple macOS versions - Tested macOS Sonoma and autopkg 2.9.0
- [x] Where logical, code updates include inline comments/docstrings