### PR TITLE
1.0.5 - Increment AutoPkg version, marking pkg_path not required, copyright updates

### DIFF
--- a/KAPPA.py
+++ b/KAPPA.py
@@ -6,7 +6,7 @@
 # License Information
 ################################################################################################
 #
-# Copyright 2024 Kandji, Inc.
+# Copyright 2026 Iru, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this
 # software and associated documentation files (the "Software"), to deal in the Software
@@ -54,7 +54,7 @@ class KAPPA(Configurator, Utilities):
     )
     input_variables = {
         "NAME": {"required": True, "description": "Name from AutoPkg recipe (used if no custom_name defined)"},
-        "pkg_path": {"required": True, "description": "Path of the built PKG for upload"},
+        "pkg_path": {"required": False, "description": "Path of the built PKG for upload"},
         "app_name": {"required": False, "description": "Name of .app in payload (for audit script)"},
         "bundleid": {
             "required": False,
@@ -222,6 +222,10 @@ class KAPPA(Configurator, Utilities):
         script_path = Path(__file__).resolve()
         # Capture exec dir path
         self.parent_dir = script_path.parent
+
+        # Ensure pkg_path is defined for post-processing
+        if "pkg_path" not in self.env:
+            raise ProcessorError("Missing required input variable: pkg_path")
 
         # Reads config and assigns needed vars for runtime
         # Also validates and populates values for Kandji/Slack (if defined)

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2024 Kandji, Inc.
+Copyright 2026 Iru, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this
 software and associated documentation files (the "Software"), to deal in the Software

--- a/helpers/configs.py
+++ b/helpers/configs.py
@@ -5,7 +5,7 @@
 # License Information
 ################################################################################################
 #
-# Copyright 2024 Kandji, Inc.
+# Copyright 2026 Iru, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this
 # software and associated documentation files (the "Software"), to deal in the Software

--- a/helpers/utils.py
+++ b/helpers/utils.py
@@ -5,7 +5,7 @@
 # License Information
 ################################################################################################
 #
-# Copyright 2024 Kandji, Inc.
+# Copyright 2026 Iru, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this
 # software and associated documentation files (the "Software"), to deal in the Software

--- a/setup.command
+++ b/setup.command
@@ -4,7 +4,7 @@
 # License Information
 ################################################################################################
 #
-# Copyright 2024 Kandji, Inc.
+# Copyright 2026 Iru, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this
 # software and associated documentation files (the "Software"), to deal in the Software
@@ -75,8 +75,8 @@ user_keychain_path=$(security login-keychain | xargs)
 
 # AutoPkg download/shasum variables
 autopkg_latest_url="https://api.github.com/repos/autopkg/autopkg/releases/latest"
-autopkg_pinned_pkg="https://github.com/autopkg/autopkg/releases/download/v2.7.3/autopkg-2.7.3.pkg"
-autopkg_pinned_shasum="1944a69aad18b0b9618b48292d115412a98ca165b626f48b11bbc59b504af082" # pragma: allowlist secret
+autopkg_pinned_pkg="https://github.com/autopkg/autopkg/releases/download/v2.9.0/autopkg-2.9.0.pkg"
+autopkg_pinned_shasum="b858161c4fe20429127a0429cdf1e6e1e2cca66b1b5ec2f81a2b98933b0a66f2" # pragma: allowlist secret
 autopkg_temp_dl="/tmp/autopkg.pkg"
 
 ##############################


### PR DESCRIPTION
## ❓ _Why This Change_
- Bug fixes, config/copyright updates

## 🆕 _What Changed_
#### **Bug fixes**:
- Addressed an issue where a PKG is created but `pkg_path` is not explicitly set as an `output_variable`
  - Set `pkg_path` `required` to `False`, with new validation to ensure it is set under `self.env`
  - Resolves https://github.com/kandji-inc/KAPPA/issues/5
#### **Miscellaneous**:
- Bumped initial AutoPkg installation version from `2.7.3` to `2.9.0` (latest)
- Updated copyright year and company name

## 🧪 _Test Results_
- [x] Validated these changes resolve identified issues present in `1.0.4`

## :shipit: _Ready Checks_
- [x] These changes have been carefully tested across multiple macOS versions
- [x] Where logical, code updates include inline comments/docstrings
