### PR TITLE
Add per-recipe enforcement_type override

### DIFF
--- a/KAPPA.py
+++ b/KAPPA.py
@@ -68,6 +68,15 @@ class KAPPA(Configurator, Utilities):
                 "Used to set specify custom app names and Self Service categories"
             ),
         },
+        "enforcement_type": {
+            "required": False,
+            "description": (
+                "Per-recipe enforcement type override. Accepted values: "
+                "'self_service', 'audit_enforce', 'install_once'. "
+                "Overrides the global li_enforcement.type set in config.json. "
+                "Has no effect if ss_category is set (self_service is implied)."
+            ),
+        },
         "create_new": {
             "required": False,
             "description": "Boolean to toggle creation of a new LI (default: False)",

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ KAPPA supports both in-recipe and centralized options for customizing your AutoP
   - Custom app name (test)
   - Self Service category
   - Self Service category (test)
+  - Enforcement type override (per-recipe)
   - Enforcement delay overrides (prod and/or test)
   - [See below](#autopkg-recipe-config) for an overview of available options and a sample config
 
@@ -308,6 +309,7 @@ Instructions for creating a Kandji API token [can be found here](https://support
 | `custom_app.test_name`   | `str` | Name of test custom app to be created/updated                       |
 | `custom_app.ss_category` | `str` | Toggles on Self Service enforcement for `prod_name` and sets category       |
 | `custom_app.test_category`| `str`| Toggles on Self Service enforcement for `test_name` and sets category  |
+| `enforcement_type`  | `str` | Per-recipe enforcement type override (`audit_enforce`\|`install_once`\|`self_service`). Overrides global `li_enforcement.type` in `config.json`. Has no effect if `ss_category` is set (self_service is implied). |
 | `enforcement_delays`| `dict`| Dictionary overriding global enforcement delay values per-recipe |
 | `enforcement_delays.prod`| `int`| Days before enforcement for production (overrides `config.json`) |
 | `enforcement_delays.test`| `int`| Days before enforcement for testing (overrides `config.json`) |
@@ -335,6 +337,8 @@ Instructions for creating a Kandji API token [can be found here](https://support
                         <key>test_category</key>
                         <string>Utilities</string>
                     </dict>
+                    <key>enforcement_type</key>
+                    <string>audit_enforce</string>
                     <key>enforcement_delays</key>
                     <dict>
                         <key>prod</key>

--- a/helpers/configs.py
+++ b/helpers/configs.py
@@ -100,6 +100,8 @@ class Configurator(Processor):
         self.recipe_custom_app = self.env.get("custom_app", None)
         # Check if recipe has enforcement delay overrides
         self.recipe_enforcement_delays = self.env.get("enforcement_delays", None)
+        # Check if recipe specifies a per-recipe enforcement type override
+        self.recipe_enforcement_type = self.env.get("enforcement_type", None)
         if self.recipe_custom_app:
             self.recipe_custom_name = self.recipe_custom_app.get("prod_name", None)
             self.recipe_test_name = self.recipe_custom_app.get("test_name", None)
@@ -163,6 +165,20 @@ class Configurator(Processor):
 
         config_enforcement = self.kappa_config.get("li_enforcement")
         enforcement_type = self._parse_enforcement(config_enforcement.get("type"))
+        # Per-recipe override takes precedence over global config (mirrors enforcement_delays behaviour)
+        if self.recipe_enforcement_type:
+            recipe_enforcement_type = self._parse_enforcement(self.recipe_enforcement_type)
+            if recipe_enforcement_type:
+                self.output(
+                    f"Recipe override: enforcement_type '{self.recipe_enforcement_type}' "
+                    f"(global: '{config_enforcement.get('type')}')"
+                )
+                enforcement_type = recipe_enforcement_type
+            else:
+                self.output(
+                    f"WARNING: Unrecognised recipe enforcement_type '{self.recipe_enforcement_type}' — "
+                    f"falling back to global config value"
+                )
         # Check if enforcement type specified, else default to once
         # May be overridden later based on recipe-specific mappings
         self.custom_app_enforcement = (


### PR DESCRIPTION
## ❓ _Why This Change_
- Recipes passing `enforcement_type` in their KAPPA `Arguments` dict had the value silently ignored — KAPPA fell through to the global `li_enforcement.type` default (typically `continuously_enforce`), causing items intended as `install_once` or `self_service` to land in Kandji with the wrong enforcement

## 🆕 _What Changed_
- Added `enforcement_type` as a recognised `input_variable`, allowing per-recipe enforcement type overrides without touching `config.json`
- Per-recipe value takes precedence over the global `li_enforcement.type`; unrecognised values warn and fall back to global config
- `ss_category` still wins — if any category is set, enforcement is always `no_enforcement` (self_service) regardless of `enforcement_type`
- Follows the same pattern as the `enforcement_delays` recipe override introduced in #7 — read from `self.env`, store on `self`, apply in `_set_defaults_enforcements()`

## 🧪 _Test Results_
```
===== autopkg run GoogleChrome.kandji.recipe -k enforcement_type=audit_enforce =====

WARNING: /Users/james.bond/git/KAPPA/GoogleChrome.kandji.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing /Users/james.bond/git/KAPPA/GoogleChrome.kandji.recipe...
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/downloads/GoogleChrome.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/downloads/GoogleChrome.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification disabled...
CodeSignatureVerifier: /private/tmp/dmg.qtx4rH/Google Chrome.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.qtx4rH/Google Chrome.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.qtx4rH/Google Chrome.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
AppDmgVersioner
AppDmgVersioner: Mounted disk image /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/downloads/GoogleChrome.dmg
AppDmgVersioner: BundleID: com.google.Chrome
AppDmgVersioner: Version: 145.0.7632.160
PkgRootCreator
PkgRootCreator: Created /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/GoogleChrome
PkgRootCreator: Created /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/GoogleChrome/Applications
Copier
Copier: Mounted disk image /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/downloads/GoogleChrome.dmg
Copier: Copied /private/tmp/dmg.sPxwgZ/Google Chrome.app to /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/GoogleChrome/Applications/Google Chrome.app
PkgCreator
PkgCreator: Package already exists at path /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/GoogleChrome-145.0.7632.160.pkg.
PkgCreator: Existing package matches version and identifier, not building.
KAPPA
KAPPA: Recipe override: enforcement_type 'audit_enforce' (global: 'audit_enforce')
KAPPA: WARNING: Default category 'Apps' not found in Self Service!
KAPPA: WARNING: Default category 'Utilities' not found in Self Service!
KAPPA: WARNING: Default category 'Apps' not found in Self Service!
KAPPA: WARNING: Default category 'Utilities' not found in Self Service!
KAPPA: Beginning file upload of GoogleChrome-145.0.7632.160.pkg...
KAPPA: Successfully uploaded GoogleChrome-145.0.7632.160.pkg!
KAPPA: WARNING: (HTTP 503): The upload is still being processed.
Retrying in five seconds...
KAPPA: SUCCESS: Custom App Create
KAPPA: Custom App 'GoogleChrome - Audit_enforce' available at '007enterprises.iru.com/library/custom-apps/9758bf53-2384-44e6-9bdd-0b13a6bfc600'
Receipt written to /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/receipts/GoogleChrome.kandji-receipt-20260305-161813.plist

Nothing downloaded, packaged or imported.

===== autopkg run GoogleChrome.kandji.recipe -k enforcement_type=install_once =====

WARNING: /Users/james.bond/git/KAPPA/GoogleChrome.kandji.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing /Users/james.bond/git/KAPPA/GoogleChrome.kandji.recipe...
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/downloads/GoogleChrome.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/downloads/GoogleChrome.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification disabled...
CodeSignatureVerifier: /private/tmp/dmg.PKyiLq/Google Chrome.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.PKyiLq/Google Chrome.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.PKyiLq/Google Chrome.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
AppDmgVersioner
AppDmgVersioner: Mounted disk image /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/downloads/GoogleChrome.dmg
AppDmgVersioner: BundleID: com.google.Chrome
AppDmgVersioner: Version: 145.0.7632.160
PkgRootCreator
PkgRootCreator: Created /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/GoogleChrome
PkgRootCreator: Created /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/GoogleChrome/Applications
Copier
Copier: Mounted disk image /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/downloads/GoogleChrome.dmg
Copier: Copied /private/tmp/dmg.ke4q80/Google Chrome.app to /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/GoogleChrome/Applications/Google Chrome.app
PkgCreator
PkgCreator: Package already exists at path /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/GoogleChrome-145.0.7632.160.pkg.
PkgCreator: Existing package matches version and identifier, not building.
KAPPA
KAPPA: Recipe override: enforcement_type 'install_once' (global: 'audit_enforce')
KAPPA: WARNING: Default category 'Apps' not found in Self Service!
KAPPA: WARNING: Default category 'Utilities' not found in Self Service!
KAPPA: WARNING: Default category 'Apps' not found in Self Service!
KAPPA: WARNING: Default category 'Utilities' not found in Self Service!
KAPPA: Beginning file upload of GoogleChrome-145.0.7632.160.pkg...
KAPPA: Successfully uploaded GoogleChrome-145.0.7632.160.pkg!
KAPPA: WARNING: (HTTP 503): The upload is still being processed.
Retrying in five seconds...
KAPPA: SUCCESS: Custom App Create
KAPPA: Custom App 'GoogleChrome - Install_once' available at '007enterprises.iru.com/library/custom-apps/9600dc60-f0ff-4428-b7ed-6aac84af53df'
Receipt written to /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/receipts/GoogleChrome.kandji-receipt-20260305-161945.plist

Nothing downloaded, packaged or imported.

===== autopkg run GoogleChrome.kandji.recipe -k enforcement_type=self_service =====

WARNING: /Users/james.bond/git/KAPPA/GoogleChrome.kandji.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
Processing /Users/james.bond/git/KAPPA/GoogleChrome.kandji.recipe...
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/downloads/GoogleChrome.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/downloads/GoogleChrome.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification disabled...
CodeSignatureVerifier: /private/tmp/dmg.QJuxaz/Google Chrome.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.QJuxaz/Google Chrome.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.QJuxaz/Google Chrome.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
AppDmgVersioner
AppDmgVersioner: Mounted disk image /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/downloads/GoogleChrome.dmg
AppDmgVersioner: BundleID: com.google.Chrome
AppDmgVersioner: Version: 145.0.7632.160
PkgRootCreator
PkgRootCreator: Created /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/GoogleChrome
PkgRootCreator: Created /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/GoogleChrome/Applications
Copier
Copier: Mounted disk image /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/downloads/GoogleChrome.dmg
Copier: Copied /private/tmp/dmg.53Wbz8/Google Chrome.app to /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/GoogleChrome/Applications/Google Chrome.app
PkgCreator
PkgCreator: Package already exists at path /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/GoogleChrome-145.0.7632.160.pkg.
PkgCreator: Existing package matches version and identifier, not building.
KAPPA
KAPPA: Recipe override: enforcement_type 'self_service' (global: 'audit_enforce')
KAPPA: WARNING: Default category 'Apps' not found in Self Service!
KAPPA: WARNING: Default category 'Utilities' not found in Self Service!
KAPPA: WARNING: Default category 'Utilities' not found in Self Service!
KAPPA: Beginning file upload of GoogleChrome-145.0.7632.160.pkg...
KAPPA: Successfully uploaded GoogleChrome-145.0.7632.160.pkg!
KAPPA: WARNING: (HTTP 503): The upload is still being processed.
Retrying in five seconds...
KAPPA: SUCCESS: Custom App Create
KAPPA: Custom App 'GoogleChrome - Self_service' available at '007enterprises.iru.com/library/custom-apps/28413117-4091-4e8b-965e-da61065cef30'
Receipt written to /Users/james.bond/Library/AutoPkg/Cache/io.kandji.test.googlechrome/receipts/GoogleChrome.kandji-receipt-20260305-162050.plist

Nothing downloaded, packaged or imported.
```

## :shipit: _Ready Checks_
- [ ] These changes have been carefully tested across multiple macOS versions
- [x] Where logical, code updates include inline comments/docstrings

## Example override usage

```xml
<key>enforcement_type</key>
<string>install_once</string>
```

Accepted values: `audit_enforce` | `install_once` | `self_service` | `continuously_enforce` | `no_enforcement`