### PR TITLE
Fix wrong variable name in example snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Instructions for creating a Kandji API token [can be found here](https://support
   },
   "use_recipe_map" : false,
   "zz_defaults" : {
-    "auto_create_new_app" : true,
+    "auto_create_app" : true,
     "dry_run" : false,
     "dynamic_lookup_fallback" : false,
     "new_app_naming" : "APPNAME (AutoPkg)",


### PR DESCRIPTION
## ❓ _Why This Change_
- The variable name in the example snippet does not exist in the code.

## 🆕 _What Changed_
- The update variable name in snippet exists in the code.

## 🧪 _Test Results_
```
I have tested with the correct variable. It works as expected
```

## :shipit: _Ready Checks_
- [x] These changes have been carefully tested across multiple macOS versions
- [x] Where logical, code updates include inline comments/docstrings
